### PR TITLE
Use encodeURI after appending params to websocket URL.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/via "0.10.0"
+(defproject com.7theta/via "0.10.1"
   :description "A re-frame library for WebSocket based messaging"
   :url "https://github.com/7theta/via"
   :license {:name "Eclipse Public License"

--- a/src/cljs/via/endpoint.cljs
+++ b/src/cljs/via/endpoint.cljs
@@ -160,4 +160,5 @@
        (st/join "&") vector
        (filter seq)
        (cons url)
-       (st/join "?")))
+       (st/join "?")
+       js/encodeURI))


### PR DESCRIPTION
Android (React Native) complains about the websocket URL if it isn't encoded.