### PR TITLE
Added option to allow manual subscription reconnection.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/via "4.3.1"
+(defproject com.7theta/via "4.4.0"
   :description "A re-frame library for WebSocket based messaging"
   :url "https://github.com/7theta/via"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Given that authentication is often performed with via after the secure socket has been established, there exists a case where the socket can be connected but no user is authenticated against it. After the initial connection/authentication, several subscriptions are typically created. If the connection is then disconnected/reconnected, the existing behaviour is to retry all subscriptions as soon as the socket is connected again.

This PR gives the calling application the option to decide when to resubscribe (i.e. after the authentication has been performed).