### PR TITLE
F/undertow migration

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -31,7 +31,7 @@
 
 (def dev-config
   (-> config
-      (assoc-in [:via/http-server :port] 3449)
+      (assoc-in [:via/http-server :http-port] 3449)
       (assoc :shadow-cljs {})))
 
 (defmethod ig/init-key :shadow-cljs [_ _]

--- a/example/resources/public/index.html
+++ b/example/resources/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" charset="UTF-8">
     <link href='https://fonts.googleapis.com/css?family=Roboto:300' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed:400,300' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto+Condensed:400,300' rel='stylesheet' type='text/css'>
     <style type="text/css">
      * {
        font-family: 'Roboto', sans-serif;

--- a/example/src/via/example/ring_handler.clj
+++ b/example/src/via/example/ring_handler.clj
@@ -11,6 +11,6 @@
        (GET "/" req-req (response/content-type
                          (response/resource-response "public/index.html")
                          "text/html"))
-       (GET  default-via-endpoint ring-req (via-handler ring-req))
+       (GET default-via-endpoint ring-req (via-handler ring-req))
        (route/resources "/"))
       (ring-defaults/wrap-defaults ring-defaults/site-defaults)))

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/via "5.1.0"
+(defproject com.7theta/via "6.0.0"
   :description "A re-frame library for WebSocket based messaging"
   :url "https://github.com/7theta/via"
   :license {:name "Eclipse Public License"
@@ -17,18 +17,18 @@
                  [haslett "0.1.6"]
 
                  [buddy/buddy-auth "2.2.0" :exclusions [clout]]
-                 [buddy/buddy-hashers "1.4.0"]
+                 [buddy/buddy-hashers "1.6.0"]
                  [com.cognitect/transit-clj "1.0.324" :exclusions [com.fasterxml.jackson.core/jackson-core]]
 
-                 [http-kit "2.4.0"]
-                 [ring/ring-core "1.8.1" :exclusions [ring/ring-codec]]
+                 [luminus/ring-undertow-adapter "1.1.2"]
+                 [ring/ring-core "1.8.2" :exclusions [ring/ring-codec]]
                  [ring/ring-defaults "0.3.2"]
                  [ring/ring-anti-forgery "1.3.0"]
                  [compojure "1.6.2"]
                  [environ "1.2.0"]
 
                  [com.7theta/distantia "0.2.2"]
-                 [com.7theta/signum "3.0.1"]
+                 [com.7theta/signum "3.0.2"]
                  [com.7theta/utilis "1.9.0"]
                  [tick "0.4.24-alpha"]
                  [integrant "0.8.0"]]
@@ -38,10 +38,10 @@
                    :env {:malli "true"}
                    :plugins [[lein-environ "0.4.0"]]
                    :dependencies [[binaryage/devtools "1.0.2"]
-                                  [thheller/shadow-cljs "2.11.1"]
-                                  [integrant/repl "0.3.1"]
+                                  [thheller/shadow-cljs "2.11.5"]
+                                  [integrant/repl "0.3.2"]
                                   [org.clojure/clojurescript "1.10.773"]
-                                  [metosin/malli "0.0.1-SNAPSHOT"]]}}
+                                  [metosin/malli "0.2.0"]]}}
   :prep-tasks ["compile"]
   :scm {:name "git"
         :url "https://github.com/7theta/via"})


### PR DESCRIPTION
Update via to use undertow as http server. This gives us support for TLS, mTLS, http/2, and more built directly into via. Examples for how to use mTLS will be forthcoming in a separate library, ```via-auth```.